### PR TITLE
Patch uuidToCatalogBrain to not be rooted to INavigationRoot

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Patch ``plone.app.uuid.utils.uuidToCatalogBrain`` to search from the portal
+  root path instead of ``INavigationRoot`` path. This allows to find content
+  from other subsites via the UUID. Objects are still secured by permission
+  checks.
+  [thet]
+
 - PEP 8.
   [thet]
 

--- a/collective/rooter/catalog.py
+++ b/collective/rooter/catalog.py
@@ -1,5 +1,9 @@
+from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.CatalogTool import CatalogTool
 from collective.rooter.navroot import getNavigationRoot
+from plone.app.uuid import utils
+import plone.api
+
 
 # Make portal_catalog's search function use a navigation root if no path
 # parameter is given
@@ -13,3 +17,25 @@ def searchResults(self, REQUEST=None, **kw):
             kw = kw.copy()
             kw['path'] = '/'.join(root.getPhysicalPath())
     return CatalogTool._oldSearchResults(self, REQUEST, **kw)
+
+
+# Patch plone.app.uuid's uuidToCatalogBrain to not be rooted to INavigationRoot
+# like searchResults above. Allow to retrieve the object, if the UUID is known.
+# Objects are still secured by permission checks.
+_oldUuidToCatalogBrain = utils.uuidToCatalogBrain
+
+
+def uuidToCatalogBrain(uuid):
+    portal = plone.api.portal.get()
+    if portal is None:
+        return None
+
+    catalog = getToolByName(portal, 'portal_catalog', None)
+    if catalog is None:
+        return None
+
+    result = catalog(UID=uuid, path=portal.getPhysicalPath())
+    if len(result) != 1:
+        return None
+
+    return result[0]

--- a/collective/rooter/configure.zcml
+++ b/collective/rooter/configure.zcml
@@ -22,4 +22,10 @@
       preservedoc="false"
       />
 
+  <monkey:patch
+      module="plone.app.uuid.utils"
+      original="uuidToCatalogBrain"
+      replacement=".catalog.uuidToCatalogBrain"
+      />
+
 </configure>

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,9 @@ setup(
         'setuptools',
         'Products.CMFPlone',
         'collective.monkeypatcher',
+        'plone.api',
         'plone.app.layout',
+        'plone.app.uuid',
         'zope.component',
         'zope.publisher',
         'zope.traversing',
@@ -38,6 +40,7 @@ setup(
     extras_require=dict(
         test=[
             'Products.PloneTestCase',
+            'plone.uuid',
         ],
     ),
     entry_points="""


### PR DESCRIPTION
Patch `plone.app.uuid.utils.uuidToCatalogBrain` to search from the portal
root path instead of `INavigationRoot` path. This allows to find content from
other subsites via the UUID. Objects are still secured by permission checks.

@optilude please review. Tests pass. Could you also grant me pypi access to collective.rooter, so that I can make a release?

@optilude I was also thinking of adding the explicit path query to the original uuidToCatalogBrain function in plone.app.uuid.utils, so that this patching isn't necessary. There was also a discussion on the plone-developers mailing list by @fredvd about bypassing the publishing dates for uuidToCatalogBrain, which do not make much sense in this context. What do you think?
