### PR TITLE
Don't root UID searches

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,10 +4,9 @@ Changelog
 1.0 (unreleased)
 ----------------
 
-- Patch ``plone.app.uuid.utils.uuidToCatalogBrain`` to search from the portal
-  root path instead of ``INavigationRoot`` path. This allows to find content
-  from other subsites via the UUID. Objects are still secured by permission
-  checks.
+- If ``UID`` is given in the catalog search keywords, don't apply the
+  INavigationRoot path. This allows for explicit queries for known objects in
+  other areas of the portal. Obsoletes pull-request #1.
   [thet]
 
 - PEP 8.

--- a/collective/rooter/catalog.py
+++ b/collective/rooter/catalog.py
@@ -1,8 +1,5 @@
-from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.CatalogTool import CatalogTool
 from collective.rooter.navroot import getNavigationRoot
-from plone.app.uuid import utils
-import plone.api
 
 
 # Make portal_catalog's search function use a navigation root if no path
@@ -11,31 +8,13 @@ CatalogTool._oldSearchResults = CatalogTool.searchResults
 
 
 def searchResults(self, REQUEST=None, **kw):
-    if 'path' not in kw and (REQUEST is None or 'path' not in REQUEST):
+    if 'UID' not in kw\
+            and 'path' not in kw\
+            and (REQUEST is None or 'path' not in REQUEST):
+        # Root catalog searches to the navigation root, except if path or UID
+        # are explicitly given.
         root = getNavigationRoot()
         if root is not None:
             kw = kw.copy()
             kw['path'] = '/'.join(root.getPhysicalPath())
     return CatalogTool._oldSearchResults(self, REQUEST, **kw)
-
-
-# Patch plone.app.uuid's uuidToCatalogBrain to not be rooted to INavigationRoot
-# like searchResults above. Allow to retrieve the object, if the UUID is known.
-# Objects are still secured by permission checks.
-_oldUuidToCatalogBrain = utils.uuidToCatalogBrain
-
-
-def uuidToCatalogBrain(uuid):
-    portal = plone.api.portal.get()
-    if portal is None:
-        return None
-
-    catalog = getToolByName(portal, 'portal_catalog', None)
-    if catalog is None:
-        return None
-
-    result = catalog(UID=uuid, path=portal.getPhysicalPath())
-    if len(result) != 1:
-        return None
-
-    return result[0]

--- a/collective/rooter/configure.zcml
+++ b/collective/rooter/configure.zcml
@@ -22,10 +22,4 @@
       preservedoc="false"
       />
 
-  <monkey:patch
-      module="plone.app.uuid.utils"
-      original="uuidToCatalogBrain"
-      replacement=".catalog.uuidToCatalogBrain"
-      />
-
 </configure>

--- a/setup.py
+++ b/setup.py
@@ -30,9 +30,7 @@ setup(
         'setuptools',
         'Products.CMFPlone',
         'collective.monkeypatcher',
-        'plone.api',
         'plone.app.layout',
-        'plone.app.uuid',
         'zope.component',
         'zope.publisher',
         'zope.traversing',
@@ -40,6 +38,7 @@ setup(
     extras_require=dict(
         test=[
             'Products.PloneTestCase',
+            'plone.app.uuid',
             'plone.uuid',
         ],
     ),


### PR DESCRIPTION
If `UID` is given in the catalog search keywords, don't apply the
INavigationRoot path. This allows for explicit queries for known objects in
other areas of the portal. Obsoletes pull-request #1.
